### PR TITLE
Recipient can view list of available foodbags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'puma', '~> 5.0'
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'rack-cors', require: 'rack/cors'
 gem 'devise_token_auth'
+gem 'active_model_serializers'
 
 group :development, :test do
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.12)
+      actionpack (>= 4.1, < 6.2)
+      activemodel (>= 4.1, < 6.2)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.0.3.4)
       activesupport (= 6.0.3.4)
       globalid (>= 0.3.6)
@@ -61,6 +66,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     coveralls (0.8.23)
@@ -95,6 +102,7 @@ GEM
     i18n (1.8.7)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
+    jsonapi-renderer (0.2.2)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -218,6 +226,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   bootsnap (>= 1.4.4)
   coveralls
   devise_token_auth

--- a/app/controllers/api/foodbags_controller.rb
+++ b/app/controllers/api/foodbags_controller.rb
@@ -1,5 +1,5 @@
 class Api::FoodbagsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, only: [:create]
 
   def create
     foodbag = current_user.foodbags.create(foodbag_params)
@@ -8,6 +8,11 @@ class Api::FoodbagsController < ApplicationController
     else
       render json: { message: foodbag.errors.full_messages.to_sentence }, status: 422
     end
+  end
+
+  def index
+    foodbags = Foodbag.all
+    render json: foodbags, each_serializer: FoodbagsIndexSerializerSerializer
   end
 
   private

--- a/app/serializers/foodbags_index_serializer_serializer.rb
+++ b/app/serializers/foodbags_index_serializer_serializer.rb
@@ -1,0 +1,3 @@
+class FoodbagsIndexSerializerSerializer < ActiveModel::Serializer
+  attributes :id, :pickuptime, :status
+end

--- a/app/serializers/foodbags_index_serializer_serializer.rb
+++ b/app/serializers/foodbags_index_serializer_serializer.rb
@@ -1,3 +1,8 @@
 class FoodbagsIndexSerializerSerializer < ActiveModel::Serializer
-  attributes :id, :pickuptime, :status
+    attributes :id, :pickuptime, :status
+    attribute :created_at do
+    object.created_at.to_formatted_s(:db)
+  end
 end
+
+

--- a/config/initializers/ams.rb
+++ b/config/initializers/ams.rb
@@ -1,0 +1,1 @@
+ActiveModelSerializers.config.adapter = :json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'api/auth', skip: [:omniauth_callbacks]
  
   namespace :api do
-    resources :foodbags, only: [:index, :show]
+    resources :foodbags, only: [:index, :show, :create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User', at: 'api/auth'
+  mount_devise_token_auth_for 'User', at: 'api/auth', skip: [:omniauth_callbacks]
  
   namespace :api do
-    resources :foodbags, only: [:create]
+    resources :foodbags, only: [:index, :show]
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    email { 'user_becomes@donor.com' }
+    email { "user_becomes#{rand(0..999)}@donor.com" }
     password { '123456' }
     password_confirmation { '123456' }
 

--- a/spec/requests/api/visitor_can_view_index_list_of_foodbags_spec.rb
+++ b/spec/requests/api/visitor_can_view_index_list_of_foodbags_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe "GET /api/foodbags" do
+  let!(:foodbags) {5.times{create(:foodbag)}}
+  
+  describe "GET /api/foodbags" do
+    before do
+      get "/api/foodbags"
+    end
+
+    it 'is expected to return a 200' do
+      expect(response).to have_http_status 200
+    end
+
+    it "is expected to return a collection of foodbags" do
+      expect(response_json['foodbags'].first['pickuptime']).to eq 'morning'
+    end
+  end
+end


### PR DESCRIPTION
[API: Recipient can view a list of available FoodBags](https://www.pivotaltracker.com/story/show/176614254)
### User Story
```
As a recipient,
In order to choose the perfect bag for me
I want to be able to see a list of available bags
```
## Changes proposed in this pull request:
* ams.rb, add gem active_model_serializers, add index action to foodbags_controler and modify before_action, created foodbags_index_serializer, modify routes, modify users.rb email to be randomnized, create spec visitor_can_view_index_list_of_foodbags correct routes with create add dateformatted to serializer
* correct routes with create
* add dateformatted to serializer
## What have we learned working on this feature:
* How to display the BE to Mobile
* To add serializers
## Packages/Gems added
* active_model_serializers
## Screenshots (Client)
![327493874](https://user-images.githubusercontent.com/72553754/106313018-d636c800-6267-11eb-9cd7-b45058014904.png)
