### PR TITLE
API Donor can edit profile information

### DIFF
--- a/app/controllers/api/user_controller.rb
+++ b/app/controllers/api/user_controller.rb
@@ -1,26 +1,38 @@
 class Api::UserController < ApplicationController
   before_action :authenticate_user!
   before_action :find_resource
+  # validates_presence_of  :user, :company_name
 
   def show
     render json: @user_profile
   end
 
   def update
-   if @user_profile.persisted? 
-    @user_profile.update(user_profile_params)
-    render json: @user_profile
-  else
-    render json:{message: 'There has been an error'}
-  end 
-end 
-    private
-
-    def user_profile_params
-      params.permit(:company_name, :adress, :city, :zipcode)
-    end
-
-    def find_resource
-      @user_profile = User.find(params[:id])
+    if user_profile_params.value?('')
+      render json: { message: 'Fields can not be empty' }, status: 400
+    elsif @user_profile.persisted?
+      @user_profile.update(user_profile_params)
+      render json: @user_profile
+    else
+      render json: { message: 'wrong wrong wrong' }
     end
   end
+  # def update
+  #   if @user_profile.persisted?
+  #     @user_profile.update(user_profile_params)
+  #     render json: @user_profile
+  #   else
+  #     render json: { message: 'There has been an error' }
+  #   end
+  # end
+
+  private
+
+  def user_profile_params
+    params.permit(:company_name, :adress, :city, :zipcode)
+  end
+
+  def find_resource
+    @user_profile = User.find(params[:id])
+  end
+end

--- a/app/controllers/api/user_controller.rb
+++ b/app/controllers/api/user_controller.rb
@@ -1,16 +1,23 @@
 class Api::UserController < ApplicationController
   before_action :authenticate_user!
-  before_action :find_user, only: :show
-
+  before_action :find_resource, only: :show
 
   def show
     render json: @user_profile
   end
 
-  private
+  def edit
+    @user = User.find(params[:id])
+  end
 
-  def find_user
+  def update
     @user_profile = User.find(params[:id])
+    @user.update
+
+    private
+
+    def find_resource
+      @user_profile = User.find(params[:id])
+    end
   end
 end
-

--- a/app/controllers/api/user_controller.rb
+++ b/app/controllers/api/user_controller.rb
@@ -1,23 +1,26 @@
 class Api::UserController < ApplicationController
   before_action :authenticate_user!
-  before_action :find_resource, only: :show
+  before_action :find_resource
 
   def show
     render json: @user_profile
   end
 
-  def edit
-    @user = User.find(params[:id])
-  end
-
   def update
-    @user_profile = User.find(params[:id])
-    @user.update
-
+   if @user_profile.persisted? 
+    @user_profile.update(user_profile_params)
+    render json: @user_profile
+  else
+    render json:{message: 'There has been an error'}
+  end 
+end 
     private
+
+    def user_profile_params
+      params.permit(:company_name, :adress, :city, :zipcode)
+    end
 
     def find_resource
       @user_profile = User.find(params[:id])
     end
   end
-end

--- a/app/controllers/api/user_controller.rb
+++ b/app/controllers/api/user_controller.rb
@@ -1,7 +1,6 @@
 class Api::UserController < ApplicationController
   before_action :authenticate_user!
   before_action :find_resource
-  # validates_presence_of  :user, :company_name
 
   def show
     render json: @user_profile
@@ -17,14 +16,6 @@ class Api::UserController < ApplicationController
       render json: { message: 'wrong wrong wrong' }
     end
   end
-  # def update
-  #   if @user_profile.persisted?
-  #     @user_profile.update(user_profile_params)
-  #     render json: @user_profile
-  #   else
-  #     render json: { message: 'There has been an error' }
-  #   end
-  # end
 
   private
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 Rails.application.routes.draw do
   get 'user/show'
+  post 'user/update'
   mount_devise_token_auth_for 'User', at: 'api/auth', skip: [:omniauth_callbacks]
 
   namespace :api do
     resources :foodbags, only: [:index, :show, :create]
-    resources :user, only: [:show, :update]
+    resources :user, only: [:show, :update, :index]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,10 @@
 Rails.application.routes.draw do
   get 'user/show'
-  patch 'user/update'
+  put 'user/update'
   mount_devise_token_auth_for 'User', at: 'api/auth', skip: [:omniauth_callbacks]
 
   namespace :api do
-    resources :foodbags, only: [:index, :show, :create]
-    resources :user, only: [:show, :update, :index]
+    resources :foodbags, only: %i[index show create]
+    resources :user, only: %i[show update index]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,4 @@
 Rails.application.routes.draw do
-  get 'user/show'
-  get 'user/update'
   mount_devise_token_auth_for 'User', at: 'api/auth', skip: [:omniauth_callbacks]
 
   namespace :api do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   get 'user/show'
-  put 'user/update'
+  get 'user/update'
   mount_devise_token_auth_for 'User', at: 'api/auth', skip: [:omniauth_callbacks]
 
   namespace :api do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   get 'user/show'
-  post 'user/update'
+  patch 'user/update'
   mount_devise_token_auth_for 'User', at: 'api/auth', skip: [:omniauth_callbacks]
 
   namespace :api do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_db_column :encrypted_password }
     it { is_expected.to have_db_column :email }
     it { is_expected.to have_db_column :tokens }
-    it { is_expected.to have_db_column :role}
-    it { is_expected.to have_db_column :adress}
-    it { is_expected.to have_db_column :name}
-    it { is_expected.to have_db_column :zipcode}
-    it { is_expected.to have_db_column :city}
+    it { is_expected.to have_db_column :role }
+    it { is_expected.to have_db_column :adress }
+    it { is_expected.to have_db_column :name }
+    it { is_expected.to have_db_column :zipcode }
+    it { is_expected.to have_db_column :city }
   end
   describe 'is expected to have validation' do
     it { is_expected.to validate_presence_of :email }

--- a/spec/requests/api/donor_can_create_foodbag_spec.rb
+++ b/spec/requests/api/donor_can_create_foodbag_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'POST /api/foodbags', type: :request do
              foodbag: {
                pickuptime: 'morning',
                status: 'available'
-
              }
            },
            headers: headers

--- a/spec/requests/api/donor_can_edit_profile_information_spec.rb
+++ b/spec/requests/api/donor_can_edit_profile_information_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe 'Api::UserController', type: :request do
-
   describe 'User can edit their profile page information ' do
     describe 'Successfully' do
       let(:user) { create(:user) }
@@ -7,7 +6,13 @@ RSpec.describe 'Api::UserController', type: :request do
       let(:user_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials) }
 
       before do
-        patch "/api/user/#{user.id}", headers: user_headers
+        put "/api/user/#{user.id}",
+              params: {
+                company_name: 'Netto',
+                adress: 'Bananvägen 258',
+                zipcode: '45678',
+                city: 'Kiruna'
+              }, headers: user_headers
       end
 
       it 'returns a 200 response status' do
@@ -15,16 +20,16 @@ RSpec.describe 'Api::UserController', type: :request do
       end
 
       it 'is expected to return updated company name' do
-        expect(response_json['company_name']).to eq user.company_name
+        expect(response_json['company_name']).to eq 'Netto'
       end
       it 'is expected to return updated adress' do
-        expect(response_json['adress']).to eq user.adress
+        expect(response_json['adress']).to eq 'Bananvägen 258'
       end
       it 'is expected to return updated zipcode' do
-        expect(response_json['zipcode']).to eq user.zipcode
+        expect(response_json['zipcode']).to eq '45678'
       end
       it 'is expected to return updated city' do
-        expect(response_json['city']).to eq user.city
+        expect(response_json['city']).to eq 'Kiruna'
       end
     end
   end

--- a/spec/requests/api/donor_can_edit_profile_information_spec.rb
+++ b/spec/requests/api/donor_can_edit_profile_information_spec.rb
@@ -1,29 +1,29 @@
 RSpec.describe 'Api::UserController', type: :request do
-  describe 'Sucessfully' do
-    describe 'User can view profie page' do
+
+  describe 'User can edit their profile page information ' do
+    describe 'Successfully' do
       let(:user) { create(:user) }
       let(:user_credentials) { user.create_new_auth_token }
       let(:user_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials) }
 
       before do
-        get "/api/user/#{user.id}",
-            headers: user_headers
+        post "/api/user/#{user.id}", headers: user_headers
       end
 
-      it 'is expected to return a 200' do
+      it 'returns a 200 response status' do
         expect(response).to have_http_status 200
       end
 
-      it 'is expected to return donors company name' do
+      it 'is expected to return updated company name' do
         expect(response_json['company_name']).to eq user.company_name
       end
-      it 'is expected to return donors adress' do
+      it 'is expected to return updated adress' do
         expect(response_json['adress']).to eq user.adress
       end
-      it 'is expected to return donors zipcode' do
+      it 'is expected to return updated zipcode' do
         expect(response_json['zipcode']).to eq user.zipcode
       end
-      it 'is expected to return donors city' do
+      it 'is expected to return updated city' do
         expect(response_json['city']).to eq user.city
       end
     end

--- a/spec/requests/api/donor_can_edit_profile_information_spec.rb
+++ b/spec/requests/api/donor_can_edit_profile_information_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Api::UserController', type: :request do
       let(:user_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials) }
 
       before do
-        post "/api/user/#{user.id}", headers: user_headers
+        patch "/api/user/#{user.id}", headers: user_headers
       end
 
       it 'returns a 200 response status' do

--- a/spec/requests/api/donor_can_edit_profile_information_spec.rb
+++ b/spec/requests/api/donor_can_edit_profile_information_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe 'Api::UserController', type: :request do
 
       before do
         put "/api/user/#{user.id}",
-              params: {
-                company_name: 'Netto',
-                adress: 'Bananvägen 258',
-                zipcode: '45678',
-                city: 'Kiruna'
-              }, headers: user_headers
+            params: {
+              company_name: 'Netto',
+              adress: 'Bananvägen 258',
+              zipcode: '45678',
+              city: 'Kiruna'
+            }, headers: user_headers
       end
 
       it 'returns a 200 response status' do
@@ -30,6 +30,36 @@ RSpec.describe 'Api::UserController', type: :request do
       end
       it 'is expected to return updated city' do
         expect(response_json['city']).to eq 'Kiruna'
+      end
+
+      describe 'Unsuccessfully' do
+        describe 'Cannot update profile with wrong information' do
+          before do
+            put "/api/user/#{user.id}",
+                params: {
+                  company_name: '',
+                  adress: '',
+                  zipcode: '',
+                  city: ''
+                }, headers: user_headers
+          end
+
+          it 'is expected to respond 400' do
+            expect(response).to have_http_status 400
+          end
+          it 'is expected to not be empty' do
+            expect(response_json['company_name']).to_not eq ''
+          end
+          it 'is expected to not be empty' do
+            expect(response_json['adress']).to_not eq ''
+          end
+          it 'is expected to not be empty' do
+            expect(response_json['zipcode']).to_not eq ''
+          end
+          it 'is expected to not be empty' do
+            expect(response_json['city']).to_not eq ''
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
[API: Donor can edit information on Profile page](https://www.pivotaltracker.com/story/show/176626834)
### User Story
```
As an API,
In order to display the correct information
I want to be able to add and update my profile
```
## Changes proposed in this pull request:
*Creating a sad path for profile information editing 
*Donor can edit profile information 
## What I have learned working on this feature:
* To be in control of the messy end 
* Finding typos
* Name conventions 

## Screenshots (Client)
![00000](https://user-images.githubusercontent.com/69510622/106367048-4c0e6280-6340-11eb-99ef-dad69366653b.png)
