### PR TITLE
Adding recipient role to user model API

### DIFF
--- a/app/controllers/api/foodbags_controller.rb
+++ b/app/controllers/api/foodbags_controller.rb
@@ -1,5 +1,6 @@
 class Api::FoodbagsController < ApplicationController
   before_action :authenticate_user!, only: [:create]
+  before_action :is_user_recipient?, only: [:index]
 
   def create
     foodbag = current_user.foodbags.create(foodbag_params)
@@ -19,5 +20,11 @@ class Api::FoodbagsController < ApplicationController
 
   def foodbag_params
     params.require(:foodbag).permit(:pickuptime, :status)
+  end
+end
+
+def is_user_recipient?
+  unless current_user.recipient?
+    render json: { message: 'You are not authorized to create an article.' }, status: 401
   end
 end

--- a/app/controllers/api/foodbags_controller.rb
+++ b/app/controllers/api/foodbags_controller.rb
@@ -1,6 +1,5 @@
 class Api::FoodbagsController < ApplicationController
-  before_action :authenticate_user!, only: [:create, :index]
-
+  before_action :authenticate_user!, only: %i[create index]
 
   def create
     foodbag = current_user.foodbags.create(foodbag_params)
@@ -22,9 +21,3 @@ class Api::FoodbagsController < ApplicationController
     params.require(:foodbag).permit(:pickuptime, :status)
   end
 end
-
-# def is_user_recipient?
-#   unless current_user.recipient?
-#     render json: { message: 'You are not authorized to create an article.' }, status: 401
-#   end
-# end

--- a/app/controllers/api/foodbags_controller.rb
+++ b/app/controllers/api/foodbags_controller.rb
@@ -1,6 +1,6 @@
 class Api::FoodbagsController < ApplicationController
   before_action :authenticate_user!, only: [:create]
-  before_action :is_user_recipient?, only: [:index]
+  # before_action :is_user_recipient?, only: [:index]
 
   def create
     foodbag = current_user.foodbags.create(foodbag_params)
@@ -23,8 +23,8 @@ class Api::FoodbagsController < ApplicationController
   end
 end
 
-def is_user_recipient?
-  unless current_user.recipient?
-    render json: { message: 'You are not authorized to create an article.' }, status: 401
-  end
-end
+# def is_user_recipient?
+#   unless current_user.recipient?
+#     render json: { message: 'You are not authorized to create an article.' }, status: 401
+#   end
+# end

--- a/app/controllers/api/foodbags_controller.rb
+++ b/app/controllers/api/foodbags_controller.rb
@@ -1,6 +1,6 @@
 class Api::FoodbagsController < ApplicationController
-  before_action :authenticate_user!, only: [:create]
-  # before_action :is_user_recipient?, only: [:index]
+  before_action :authenticate_user!, only: [:create, :index]
+
 
   def create
     foodbag = current_user.foodbags.create(foodbag_params)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,13 @@
 class ApplicationController < ActionController::API
-        include DeviseTokenAuth::Concerns::SetUserByToken
+  include DeviseTokenAuth::Concerns::SetUserByToken
+
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    added_attrs = %i[email password password_confirmation role]  # add the attributes you want
+    devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
+    devise_parameter_sanitizer.permit :account_update, keys: added_attrs
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ActiveRecord::Base
 
   after_initialize :set_default_role, if: :new_record?
 
-  enum role: %i[donor]
+  enum role: %i[donor recipient]
 
   has_many :foodbags, foreign_key: 'donor_id'
   has_one_attached :image

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,10 +15,10 @@ class User < ActiveRecord::Base
   def image_path
     Rails.env.test? ? ActiveStorage::Blob.service.path_for(image.key) : image.service_url(expires_in: 1.hour, disposition: 'inline')
   end
-  end
+end
 
   private
 
-  def set_default_role
-    self.role ||= :donor
-  end
+def set_default_role
+  self.role ||= :donor
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,11 +44,6 @@ ActiveRecord::Schema.define(version: 2021_01_31_205034) do
     t.integer "donor_id", null: false
   end
 
-  create_table "profiles", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "users", force: :cascade do |t|
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,5 +11,9 @@ FactoryBot.define do
     factory :donor do
       role { :donor }
     end
+
+    factory :recipient do
+      role { :recipient }
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe User, type: :model do
     it 'is expected to have a valid user factory bot' do
       expect(create(:user, email: 'user_becomes@donor.com')).to be_valid
     end
+    it 'is expected to have a valid recipient factory bot' do
+      expect(create(:recipient, email: 'user_becomes@recipient.com')).to be_valid
+    end
+
   end
   describe 'is expected to have db colums' do
     it { is_expected.to have_db_column :encrypted_password }

--- a/spec/requests/api/recpient_can_register_on_mobile_spec.rb
+++ b/spec/requests/api/recpient_can_register_on_mobile_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe 'POST /api/auth', type: :request do
   describe 'with valid credentials' do
     before do
       post '/api/auth',
-          params: {
-            email: 'user_becomes@recipient.com',
-            password: '123456',
-            password_confirmation: '123456',
-            role: 'recipient'
-          },
-          headers: headers
+           params: {
+             email: 'user_becomes@recipient.com',
+             password: '123456',
+             password_confirmation: '123456',
+             role: 'recipient'
+           },
+           headers: headers
     end
 
     it 'returns a 200 response status' do

--- a/spec/requests/api/recpient_can_register_on_mobile_spec.rb
+++ b/spec/requests/api/recpient_can_register_on_mobile_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe 'POST /api/auth', type: :request do
+  let(:recipient) { create(:recipient) }
+  let(:recipient_headers) { recipient.create_new_auth_token }
+
+  describe 'with valid credentials' do
+    before do
+      post '/api/auth',
+          params: {
+            email: 'user_becomes@recipient.com',
+            password: '123456',
+            password_confirmation: '123456',
+            role: 'recipient'
+          },
+          headers: headers
+    end
+
+    it 'returns a 200 response status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'returns a success message' do
+      expect(response_json['status']).to eq 'success'
+    end
+  end
+end

--- a/spec/requests/api/visitor_can_view_index_list_of_foodbags_spec.rb
+++ b/spec/requests/api/visitor_can_view_index_list_of_foodbags_spec.rb
@@ -1,16 +1,19 @@
-RSpec.describe "GET /api/foodbags" do
-  let!(:foodbags) {5.times{create(:foodbag)}}
-  
-  describe "GET /api/foodbags" do
+RSpec.describe 'GET /api/foodbags' do
+  let!(:foodbags) { 5.times { create(:foodbag) } }
+  let(:recipient) { create(:recipient) }
+  let(:recipient_headers) { recipient.create_new_auth_token }
+
+  describe 'GET /api/foodbags' do
     before do
-      get "/api/foodbags"
+      get '/api/foodbags',
+          headers: recipient_headers
     end
 
     it 'is expected to return a 200' do
       expect(response).to have_http_status 200
     end
 
-    it "is expected to return a collection of foodbags" do
+    it 'is expected to return a collection of foodbags' do
       expect(response_json['foodbags'].first['pickuptime']).to eq 'morning'
     end
   end


### PR DESCRIPTION
[MOBILE: Recipient can register in API](https://www.pivotaltracker.com/story/show/176623685)
### User Story
```
As an API,
In order to provide the visitor with access
I would like to allow visitor to create an account
```
## Changes proposed in this pull request:
* Adding authentication to index action
* Adding role to recipient
* 
## What I have learned working on this feature:
* working with association 
## Packages/Gems added
*
## Screenshots (Client)