### PR TITLE
Recipient can reserve a foodbag from index list API

### DIFF
--- a/app/controllers/api/foodbags_controller.rb
+++ b/app/controllers/api/foodbags_controller.rb
@@ -2,7 +2,7 @@ class Api::FoodbagsController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    foodbag = Foodbag.create(pickuptime: params['foodbag']['pickuptime'], doner_id: current_user.id)
+    foodbag = Foodbag.create(pickuptime: params['foodbag']['pickuptime'], donor_id: current_user.id)
     if foodbag.persisted?
       render json: { message: 'Your foodbag was successfully created!' }, status: 201
     else
@@ -24,8 +24,4 @@ class Api::FoodbagsController < ApplicationController
       render json: { message: foodbag.errors.full_messages.to_sentence }, status: 422
     end
   end
-
-  # def foodbag_params
-  #   params.require(:foodbag).permit(:pickuptime)
-  # end
 end

--- a/app/controllers/api/foodbags_controller.rb
+++ b/app/controllers/api/foodbags_controller.rb
@@ -17,9 +17,8 @@ class Api::FoodbagsController < ApplicationController
 
   def update
     foodbag = Foodbag.find(params["id"])
-    foodbag.update(status: params["foodbag"]["status"])
+    foodbag.update(status: params["foodbag"]["status"], recipient_id: current_user.id)
     render json: { message: 'Your foodbag is reserved!' }
-    # binding.pry
   end
   private
 

--- a/app/controllers/api/foodbags_controller.rb
+++ b/app/controllers/api/foodbags_controller.rb
@@ -1,8 +1,8 @@
 class Api::FoodbagsController < ApplicationController
-  before_action :authenticate_user! 
+  before_action :authenticate_user!
 
   def create
-    foodbag = current_user.foodbags.create(foodbag_params)
+    foodbag = Foodbag.create(pickuptime: params['foodbag']['pickuptime'], doner_id: current_user.id)
     if foodbag.persisted?
       render json: { message: 'Your foodbag was successfully created!' }, status: 201
     else
@@ -16,13 +16,16 @@ class Api::FoodbagsController < ApplicationController
   end
 
   def update
-    foodbag = Foodbag.find(params["id"])
-    foodbag.update(status: params["foodbag"]["status"], recipient_id: current_user.id)
-    render json: { message: 'Your foodbag is reserved!' }
+    foodbag = Foodbag.find(params['id'])
+    foodbag.update(status: params['foodbag']['status'], recipient_id: current_user.id)
+    if foodbag.save
+      render json: { message: 'Your foodbag is reserved!' }
+    else
+      render json: { message: foodbag.errors.full_messages.to_sentence }, status: 422
+    end
   end
-  private
 
-  def foodbag_params
-    params.require(:foodbag).permit(:pickuptime, :status, :donor_id)
-  end
+  # def foodbag_params
+  #   params.require(:foodbag).permit(:pickuptime)
+  # end
 end

--- a/app/controllers/api/foodbags_controller.rb
+++ b/app/controllers/api/foodbags_controller.rb
@@ -1,5 +1,5 @@
 class Api::FoodbagsController < ApplicationController
-  before_action :authenticate_user!, only: %i[create index]
+  before_action :authenticate_user! 
 
   def create
     foodbag = current_user.foodbags.create(foodbag_params)
@@ -15,9 +15,15 @@ class Api::FoodbagsController < ApplicationController
     render json: foodbags, each_serializer: FoodbagsIndexSerializerSerializer
   end
 
+  def update
+    foodbag = Foodbag.find(params["id"])
+    foodbag.update(status: params["foodbag"]["status"])
+    render json: { message: 'Your foodbag is reserved!' }
+    # binding.pry
+  end
   private
 
   def foodbag_params
-    params.require(:foodbag).permit(:pickuptime, :status)
+    params.require(:foodbag).permit(:pickuptime, :status, :donor_id)
   end
 end

--- a/app/models/foodbag.rb
+++ b/app/models/foodbag.rb
@@ -4,5 +4,4 @@ class Foodbag < ApplicationRecord
   validates_presence_of :pickuptime, :status
   belongs_to :donor, class_name: 'User'
   belongs_to :recipient, class_name: 'User', optional: true
-  # scope :not_available, -> (status) {where(status: status)}
 end

--- a/app/models/foodbag.rb
+++ b/app/models/foodbag.rb
@@ -3,4 +3,6 @@ class Foodbag < ApplicationRecord
   enum status: %i[available reserved collected]
   validates_presence_of :pickuptime, :status
   belongs_to :donor, class_name: 'User'
+  belongs_to :recipient, class_name: 'User', optional: true
+  # scope :not_available, -> (status) {where(status: status)}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ActiveRecord::Base
   enum role: %i[donor recipient]
 
   has_many :foodbags, foreign_key: 'donor_id'
+  has_many :foodbags, foreign_key: 'recipient_id'
   has_one_attached :image
 
   devise :database_authenticatable, :registerable,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'api/auth', skip: [:omniauth_callbacks]
 
   namespace :api do
-    resources :foodbags, only: %i[index show create]
+    resources :foodbags, only: %i[index show create update]
     resources :user, only: %i[show update index]
   end
 end

--- a/db/migrate/20210204121841_food_bag_belongs_to_recipient.rb
+++ b/db/migrate/20210204121841_food_bag_belongs_to_recipient.rb
@@ -1,0 +1,5 @@
+class FoodBagBelongsToRecipient < ActiveRecord::Migration[6.0]
+  def change
+    add_column :foodbags, :recipient_id, :integer, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_31_205034) do
+ActiveRecord::Schema.define(version: 2021_02_04_121841) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 2021_01_31_205034) do
     t.integer "pickuptime"
     t.integer "status", default: 0
     t.integer "donor_id", null: false
+    t.integer "recipient_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/foodbags.rb
+++ b/spec/factories/foodbags.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :foodbag do
     pickuptime { :morning }
     status { :available }
-    association :donor, factory: :user
+    association :donor, factory: :donor
+    # association :recipient, factory: :recipient
   end
 end

--- a/spec/factories/foodbags.rb
+++ b/spec/factories/foodbags.rb
@@ -3,6 +3,5 @@ FactoryBot.define do
     pickuptime { :morning }
     status { :available }
     association :donor, factory: :donor
-    # association :recipient, factory: :recipient
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,12 +4,11 @@ RSpec.describe User, type: :model do
       expect(create(:user)).to be_valid
     end
     it 'is expected to have a valid user factory bot' do
-      expect(create(:user, email: 'user_becomes@donor.com')).to be_valid
+      expect(create(:donor, email: 'user_becomes@donor.com')).to be_valid
     end
     it 'is expected to have a valid recipient factory bot' do
       expect(create(:recipient, email: 'user_becomes@recipient.com')).to be_valid
     end
-
   end
   describe 'is expected to have db colums' do
     it { is_expected.to have_db_column :encrypted_password }

--- a/spec/requests/api/donor_can_create_foodbag_spec.rb
+++ b/spec/requests/api/donor_can_create_foodbag_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'POST /api/foodbags', type: :request do
            params: {
              foodbag: {
                pickuptime: 'morning'
-               #  donor_id: donor.id
              }
            },
            headers: headers

--- a/spec/requests/api/donor_can_create_foodbag_spec.rb
+++ b/spec/requests/api/donor_can_create_foodbag_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'POST /api/foodbags', type: :request do
            params: {
              foodbag: {
                pickuptime: 'morning'
-
+               #  donor_id: donor.id
              }
            },
            headers: headers
@@ -38,29 +38,7 @@ RSpec.describe 'POST /api/foodbags', type: :request do
     end
 
     it 'is expected to return a error message' do
-      expect(response_json['message']).to eq "Pickuptime can't be blank and Donor must exist"
-    end
-  end
-
-  describe 'unsuccessfully create a foodbag without status available' do
-    before do
-      post '/api/foodbags',
-           params: {
-             foodbag: {
-               pickuptime: 'evening',
-               status: ''
-
-             }
-           },
-           headers: headers
-    end
-
-    it 'is expected to return a 422' do
-      expect(response).to have_http_status 422
-    end
-
-    it 'is expected to return a error message' do
-      expect(response_json['message']).to eq "Status can't be blank and Donor must exist"
+      expect(response_json['message']).to eq "Pickuptime can't be blank"
     end
   end
 

--- a/spec/requests/api/donor_can_create_foodbag_spec.rb
+++ b/spec/requests/api/donor_can_create_foodbag_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe 'POST /api/foodbags', type: :request do
-  let(:donor) { create(:user) }
+  let(:donor) { create(:donor) }
   let(:headers) { donor.create_new_auth_token }
   describe 'successfully create a foodbag' do
     before do
       post '/api/foodbags',
-          params: {
+           params: {
              foodbag: {
-               pickuptime: 'morning',
-               status: 'available'
+               pickuptime: 'morning'
+
              }
            },
            headers: headers
@@ -26,8 +26,7 @@ RSpec.describe 'POST /api/foodbags', type: :request do
       post '/api/foodbags',
            params: {
              foodbag: {
-               pickuptime: '',
-               status: 'available'
+               pickuptime: ''
 
              }
            },
@@ -39,7 +38,7 @@ RSpec.describe 'POST /api/foodbags', type: :request do
     end
 
     it 'is expected to return a error message' do
-      expect(response_json['message']).to eq "Pickuptime can't be blank"
+      expect(response_json['message']).to eq "Pickuptime can't be blank and Donor must exist"
     end
   end
 
@@ -61,7 +60,7 @@ RSpec.describe 'POST /api/foodbags', type: :request do
     end
 
     it 'is expected to return a error message' do
-      expect(response_json['message']).to eq "Status can't be blank"
+      expect(response_json['message']).to eq "Status can't be blank and Donor must exist"
     end
   end
 

--- a/spec/requests/api/recipient_can_reserv_a_foodbag_spec.rb
+++ b/spec/requests/api/recipient_can_reserv_a_foodbag_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe 'PUT /api/foodbags/:id', type: :request do
+  let(:foodbag) { create(:foodbag) }
+  let(:recipient) { create(:recipient) }
+  let(:recipient_headers) { recipient.create_new_auth_token }
+
+  describe 'recipient can reserv a foodbag' do
+    before do
+      put "/api/foodbags/#{foodbag.id}",
+          params: {
+            foodbag: {
+              status: 'reserved'
+            }
+          },
+          headers: recipient_headers
+    end
+
+    it 'ist expected ro return a 200' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to return a success message' do
+      expect(response_json['message']).to eq 'Your foodbag is reserved!'
+    end
+
+    it 'is expected to belong to the current user' do
+      expect(foodbag.reload.user_id).to eq recipient.id
+    end
+  end
+end

--- a/spec/requests/api/recipient_can_reserv_a_foodbag_spec.rb
+++ b/spec/requests/api/recipient_can_reserv_a_foodbag_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'PUT /api/foodbags/:id', type: :request do
     end
 
     it 'is expected to belong to the current user' do
-      expect(foodbag.reload.user_id).to eq recipient.id
+      expect(foodbag.reload.recipient_id).to eq recipient.id
     end
   end
 end

--- a/spec/requests/api/recipient_can_reserv_a_foodbag_spec.rb
+++ b/spec/requests/api/recipient_can_reserv_a_foodbag_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'PUT /api/foodbags/:id', type: :request do
           }
     end
 
-    it 'ist expected ro return a 401' do
+    it 'is expected to return a 401' do
       expect(response).to have_http_status 401
     end
 

--- a/spec/requests/api/recipient_can_reserv_a_foodbag_spec.rb
+++ b/spec/requests/api/recipient_can_reserv_a_foodbag_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'PUT /api/foodbags/:id', type: :request do
   let(:recipient) { create(:recipient) }
   let(:recipient_headers) { recipient.create_new_auth_token }
 
-  describe 'recipient can reserv a foodbag' do
+  describe 'recipient can successfully reserv a foodbag' do
     before do
       put "/api/foodbags/#{foodbag.id}",
           params: {
@@ -24,6 +24,45 @@ RSpec.describe 'PUT /api/foodbags/:id', type: :request do
 
     it 'is expected to belong to the current user' do
       expect(foodbag.reload.recipient_id).to eq recipient.id
+    end
+  end
+
+  describe "visitor can't reserv a foodbag" do
+    before do
+      put "/api/foodbags/#{foodbag.id}",
+          params: {
+            foodbag: {
+              status: 'reserved'
+            }
+          }
+    end
+
+    it 'ist expected ro return a 401' do
+      expect(response).to have_http_status 401
+    end
+
+    it 'is expected to return an error message' do
+      expect(response_json).to have_key('errors').and have_value(['You need to sign in or sign up before continuing.'])
+    end
+  end
+
+  describe "recipient can't reserv a foodbag without valid status" do
+    before do
+      put "/api/foodbags/#{foodbag.id}",
+          params: {
+            foodbag: {
+              status: ''
+            }
+          },
+          headers: recipient_headers
+    end
+
+    it 'ist expected ro return a 422' do
+      expect(response).to have_http_status 422
+    end
+
+    it 'is expected to return an error message' do
+      expect(response_json).to have_key('message').and have_value("Status can't be blank")
     end
   end
 end


### PR DESCRIPTION
Recipient can reserve a foodbag from index list](https://www.pivotaltracker.com/story/show/176800073)
### User Story
```
As an API,
In order to make sure a recipient can access a foodbag
I want to make sure that a foodbag can be reserved
```
## Changes proposed in this pull request:
* Recipient can update foodbag status to reserved
## What I have learned working on this feature:
* PUT requests
## Packages/Gems added
*
## Screenshots (Client)